### PR TITLE
Make compatible with wxPython 3.0

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,6 @@
+Authors
+-------
+
+- [Ram Rachum](https://github.com/cool-RR), original author
+- [Peter Bittner](https://github.com/bittner), contributor
+- [Chris van Es](https://github.com/cvanes), contributor

--- a/README.markdown
+++ b/README.markdown
@@ -5,16 +5,18 @@ PythonTurtle strives to provide the lowest-threshold way to learn Python. Studen
 
 ![Screen shot](http://pythonturtle.org/images/screenshot.gif)
 
-Tested with Python 2.6 and wxPython 2.8.10.1. Currently tested only on Windows and Ubuntu.
+Tested with Python version 2.6, 2.7 and wxPython versions 2.8.10.1, 3.0.2.0.
+Currently manually tested only on Windows and Ubuntu Linux.
 
 This project is licensed under the MIT license.
 
-PythonTurtle was created by Ram Rachum as a side-project in 2009. I also provide 
+PythonTurtle was created by Ram Rachum as a side-project in 2009. I also provide
 [freelance Django/Python development services](https://chipmunkdev.com).
 
 Installing on Linux:
 
-    sudo apt-get install python-wxgtk2.8 git -y
+    sudo apt-get install python-wxgtk3.0 git -y
+    # NOTE: install `python-wxgtk2.8` on olders systems
     git clone https://github.com/cool-RR/PythonTurtle.git
     cd PythonTurtle/src
     python pythonturtle.py

--- a/src/pythonturtle.py
+++ b/src/pythonturtle.py
@@ -154,7 +154,11 @@ class ApplicationWindow(wx.Frame):
                     for [caption, bitmap_file] in self.help_images_list]
 
         for page in self.help_pages:
-            self.help_notebook.AddPage(page, caption=page.caption)
+            try:
+                # avoid TypeError: Required argument 'text' in wxPython > 2.9
+                self.help_notebook.AddPage(page, text=page.caption)
+            except TypeError:
+                self.help_notebook.AddPage(page, caption=page.caption)
 
         self.help_close_button_panel = wx.Panel(parent=self.help_screen)
         self.help_screen_sizer = wx.BoxSizer(wx.VERTICAL)
@@ -206,7 +210,7 @@ class ApplicationWindow(wx.Frame):
 An educational environment for learning Python, suitable for beginners and children.
 Inspired by LOGO.
 
-Runs on Python 2.6, using wxPython, Psyco and py2exe. Thanks go to the developers
+Runs on Python 2.6/2.7, using wxPython, Psyco and py2exe. Thanks go to the developers
 responsible for these projects, as well as to the helpful folks at the user groups
 of these projects, and at StackOverflow.com, who have helped solved many problems
 that came up in the making of this program."""
@@ -236,8 +240,12 @@ class HelpPage(CustomScrolledPanel):
 
 def run():
     multiprocessing.freeze_support()
-    app = wx.PySimpleApp()
-    my_app_win = ApplicationWindow(None,-1,"PythonTurtle",size=(600,600))
+    try:
+        # anticipate deprecation (wxPyDeprecationWarning in wxPython >= 2.9)
+        app = wx.PySimpleApp()
+    except AttributeError:
+        app = wx.App()
+    ApplicationWindow(None, -1, "PythonTurtle", size=(600, 600))
     #import cProfile; cProfile.run("app.MainLoop()")
     app.MainLoop()
 


### PR DESCRIPTION
This PR adds compatibility code for running _PythonTurtle_ on Ubuntu 16.04.1 Xenial with `python-wxgtk3.0` and Python 2.7.12.

References
-------------

- [wxPython API docs](https://www.wxpython.org/docs/api/)
- [(partly) related SO question](http://stackoverflow.com/questions/15144168/error-using-deprecated-class-pysimpleapp-after-removing-epd)