### PR TITLE
Add Fedora installation instructions.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@ PythonTurtle strives to provide the lowest-threshold way to learn Python. Studen
 ![Screen shot](http://pythonturtle.org/images/screenshot.gif)
 
 Tested with Python version 2.6, 2.7 and wxPython versions 2.8.10.1, 3.0.2.0.
-Currently manually tested only on Windows and Ubuntu Linux.
+Currently manually tested only on Windows, Ubuntu Linux, and Fedora Linux.
 
 This project is licensed under the MIT license.
 
@@ -15,8 +15,13 @@ PythonTurtle was created by Ram Rachum as a side-project in 2009. I also provide
 
 Installing on Linux:
 
+    # Ubuntu:
     sudo apt-get install python-wxgtk3.0 git -y
     # NOTE: install `python-wxgtk2.8` on olders systems
+
+    # Fedora:
+    dnf install wxPython
+
     git clone https://github.com/cool-RR/PythonTurtle.git
     cd PythonTurtle/src
     python pythonturtle.py


### PR DESCRIPTION
Works fine, but it took me a minute to figure out what the wxPython
package is called in Fedora.