### PR TITLE
Add test+build infrastructure (Tox and Travis CI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
+__pycache__/
 osx_build/
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+---
+language: python
+python:
+  - 2.6
+  - 2.7
+  - 3.5
+  - 3.6
+  - 3.7
+  - pypy
+  - pypy3
+
+stages:
+  - lint
+  - test
+  - build
+
+env:  # enable allow_failures
+matrix:
+  allow_failures:
+    - env: TOXENV=flake8
+    - env: TOXENV=pylint
+
+jobs:
+  include:
+    - { stage: lint, python: 2.7, env: TOXENV=flake8 }
+    - { stage: lint, python: 3.6, env: TOXENV=flake8 }
+    - { stage: lint, python: 2.7, env: TOXENV=pylint }
+    - { stage: lint, python: 3.6, env: TOXENV=pylint }
+
+install: pip install tox-travis
+script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+envlist =
+    flake8
+    pylint
+    py26
+    py27
+    py35
+    py36
+    py37
+    pypy
+    pypy3
+skipsdist = true
+
+[testenv:flake8]
+deps = flake8
+commands = flake8 {posargs}
+
+[testenv:pylint]
+deps = pylint
+commands = pylint --rcfile tox.ini {posargs:src}
+
+[flake8]
+exclude = .cache,.git,.tox
+
+[pylint]
+reports = no


### PR DESCRIPTION
First steps towards automatic builds. Adds:

- a Tox configuration for running linting and tests (locally), and
- a Travis CI configuration.

See https://travis-ci.org/bittner/PythonTurtle while I'm testing the results of this implementation.