### PR TITLE
Add badges to README, restructure content, green builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - 2.7
   - 3.5
   - 3.6
-  - 3.7
   - pypy
   - pypy3
 
@@ -26,6 +25,7 @@ jobs:
     - { stage: lint, python: 3.6, env: TOXENV=flake8 }
     - { stage: lint, python: 2.7, env: TOXENV=pylint }
     - { stage: lint, python: 3.6, env: TOXENV=pylint }
+    - { stage: test, python: 3.7, dist: xenial, sudo: true }
 
 install: pip install tox-travis
 script: tox

--- a/README.md
+++ b/README.md
@@ -1,27 +1,73 @@
-Homepage: [http://pythonturtle.org](http://pythonturtle.org)
-A Windows installer is available from there.
+Python Turtle
+=============
 
-PythonTurtle strives to provide the lowest-threshold way to learn Python. Students command an interactive Python shell (similar to the IDLE development environment) and use Python functions to move a turtle displayed on the screen. An illustrated help screen introduces the student to the basics of Python programming while demonstrating how to move the turtle.
+[![Build Status](https://img.shields.io/travis/cool-RR/PythonTurtle/master.svg)](https://travis-ci.org/cool-RR/PythonTurtle
+) [![GitHub issues](https://img.shields.io/github/issues-raw/cool-RR/PythonTurtle.svg)](https://github.com/cool-RR/PythonTurtle/issues
+) [![GitHub PRs](https://img.shields.io/github/issues-pr-raw/cool-RR/PythonTurtle.svg)](https://github.com/cool-RR/PythonTurtle/pulls
+) [![MIT License](https://img.shields.io/github/license/cool-RR/PythonTurtle.svg)](https://github.com/cool-RR/PythonTurtle/blob/master/LICENSE)
+
+An educational environment for learning Python, suitable for beginners and children.
+Inspired by LOGO.
+
+Homepage: [http://pythonturtle.org](http://pythonturtle.org)
+
+An Appealing Environment to Learn Python
+----------------------------------------
+
+PythonTurtle strives to provide the lowest-threshold way to learn Python.
+Students command an interactive Python shell (similar to the [IDLE development
+environment](https://docs.python.org/3/library/idle.html)) and use Python
+functions to move a turtle displayed on the screen.
+
+An illustrated help screen introduces the student to the basics of Python
+programming while demonstrating how to move the turtle. Simplicity and a
+colorful visual appearance makes the learning environment more appealing
+to students.
 
 ![Screen shot](http://pythonturtle.org/images/screenshot.gif)
 
+Installation
+------------
+
+Installers for Microsoft Windows and macOS are available from
+[pythonturtle.org](http://pythonturtle.org).
+
+Ubuntu Linux:
+
+```bash
+# NOTE: install `python-wxgtk2.8` on older systems
+sudo apt-get install -y git python-wxgtk3.0
+```
+
+Fedora:
+
+```bash
+dnf install wxPython
+```
+
+On any GNU/Linux distribution: (after installing prerequisites from above)
+
+```bash
+git clone https://github.com/cool-RR/PythonTurtle.git
+cd PythonTurtle/src
+python pythonturtle.py
+```
+
+If you're into automation:
+
+[Ansible tasks](https://github.com/painless-software/ansible-software/blob/master/roles/education/tasks/main.yml#L11-L33
+) for setting up PythonTurtle including a desktop shortcut for GNOME.
+
+Compatibility
+-------------
+
 Tested with Python version 2.6, 2.7 and wxPython versions 2.8.10.1, 3.0.2.0.
-Currently manually tested only on Windows, Ubuntu Linux, and Fedora Linux.
+Currently manually tested only on Windows, macOS, Ubuntu Linux, and Fedora.
+
+About
+-----
 
 This project is licensed under the MIT license.
 
 PythonTurtle was created by Ram Rachum as a side-project in 2009. I also provide
 [freelance Django/Python development services](https://chipmunkdev.com).
-
-Installing on Linux:
-
-    # Ubuntu:
-    sudo apt-get install python-wxgtk3.0 git -y
-    # NOTE: install `python-wxgtk2.8` on olders systems
-
-    # Fedora:
-    dnf install wxPython
-
-    git clone https://github.com/cool-RR/PythonTurtle.git
-    cd PythonTurtle/src
-    python pythonturtle.py


### PR DESCRIPTION
Adds a few sweet badges at the top of the README  and restructures the content.

Please only merge, when the Travis build is **green**! -- I may add a few more commits to make this happen.