### PR TITLE
Add Sergey Klimov to list of authors, align sort order

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,5 +2,7 @@ Authors
 -------
 
 - [Ram Rachum](https://github.com/cool-RR), original author
-- [Peter Bittner](https://github.com/bittner), contributor
 - [Chris van Es](https://github.com/cvanes), contributor
+- [Peter Bittner](https://github.com/bittner), contributor
+- [Ryne Everett](https://github.com/ryneeverett), contributor
+- [Sergey Klimov](https://github.com/darvin), contributor

--- a/src/resources/developers.txt
+++ b/src/resources/developers.txt
@@ -1,4 +1,5 @@
-Ram Rachum
-Chris van Es
-Ryne Everett
-Peter Bittner
+Ram Rachum (original author)
+Chris van Es (contributor)
+Peter Bittner (contributor)
+Ryne Everett (contributor)
+Sergey Klimov (contributor)


### PR DESCRIPTION
As mentioned in https://github.com/cool-RR/PythonTurtle/pull/88#issuecomment-424455132.

I also adjusted and aligned the sort order (original author first, then contributors in alphabetical order of first name).