### PR TITLE
Build Python package for PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,14 @@
+# Python byte code files
 *.py[co]
 __pycache__/
-osx_build/
-.tox/
+
+# editors and IDE's
 *.wpu
+
+# testing artifacts
+/.tox/
+
+# packaging artifacts
+/build/
+/dist/
+/*.spec

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,10 @@ __pycache__/
 
 # testing artifacts
 /.tox/
+/tests/reports/
 
 # packaging artifacts
 /build/
 /dist/
+/*.egg-info
 /*.spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ language: python
 python:
   - 3.6
   - 3.7
-  - pypy3
 
 stages:
   - lint
@@ -17,7 +16,6 @@ env:  # enable allow_failures
 matrix:
   allow_failures:
     - env: TOXENV=pylint
-    - python: pypy3
     - python: 3.7
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ env:  # enable allow_failures
 matrix:
   allow_failures:
     - env: TOXENV=pylint
-    - env: TOXENV=pypy3
-    - env: TOXENV=py37
+    - python: pypy3
+    - python: 3.7
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 ---
 language: python
 python:
-  - pypy
-  - 2.6
-  - 2.7
   - pypy3
-  - 3.5
   - 3.6
 
 stages:
@@ -16,21 +12,19 @@ stages:
 env:  # enable allow_failures
 matrix:
   allow_failures:
-    - env: TOXENV=flake8
     - env: TOXENV=pylint
+    - env: TOXENV=pypy3
+    - env: TOXENV=py37
 
 jobs:
   include:
-    - { stage: lint, python: 2.7, env: TOXENV=flake8 }
     - { stage: lint, python: 3.6, env: TOXENV=flake8 }
-    - { stage: lint, python: 2.7, env: TOXENV=pylint }
     - { stage: lint, python: 3.6, env: TOXENV=pylint }
     - { stage: test, python: 3.7, dist: xenial, sudo: true }
 
 before_install:
   - sudo apt-get update
   - PYTHON_MAJOR=$(python -c 'import sys; print(sys.version[0])')
-  - if [ $PYTHON_MAJOR = '2' ]; then sudo apt-get install -y python-wxgtk2.8; fi
   # - if [ $PYTHON_MAJOR = '3' ]; then sudo apt-get install -y python3-wxgtk4.0; fi
   - dpkg -l *wxgtk*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 ---
+dist: xenial
+sudo: true
+
 language: python
 python:
-  - pypy3
   - 3.6
+  - 3.7
+  - pypy3
 
 stages:
   - lint
@@ -20,7 +24,6 @@ jobs:
   include:
     - { stage: lint, python: 3.6, env: TOXENV=flake8 }
     - { stage: lint, python: 3.6, env: TOXENV=pylint }
-    - { stage: test, python: 3.7, dist: xenial, sudo: true }
 
 before_install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 stages:
   - lint
   - test
-  - build
+  - publish
 
 env:  # enable allow_failures
 matrix:
@@ -22,6 +22,16 @@ jobs:
   include:
     - { stage: lint, python: 3.6, env: TOXENV=flake8 }
     - { stage: lint, python: 3.6, env: TOXENV=pylint }
+
+    - stage: publish
+      script: skip
+      deploy:
+        provider: pypi
+        user: coolRR
+        password:
+          secure: <travis-encrypt-value-here>
+      on:
+        tags: true
 
 before_install:
   - sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ On any GNU/Linux distribution: (after installing prerequisites from above)
 
 ```bash
 git clone https://github.com/cool-RR/PythonTurtle.git
-cd PythonTurtle/src
-python3 pythonturtle.py
+cd PythonTurtle
+python3 -m pythonturtle
 ```
 
 If you're into automation:

--- a/pythonturtle/__init__.py
+++ b/pythonturtle/__init__.py
@@ -9,5 +9,7 @@ turtle that is displayed on the screen. An illustrated help screen
 demonstrates how to move the turtle and introduces the student to the
 basics of Python programming.
 """
-__version__ = '0.3.0'
+__license__ = 'MIT'
+__product_name__ = 'PythonTurtle'
 __url__ = 'http://pythonturtle.org'
+__version__ = '0.3.0'

--- a/pythonturtle/application.py
+++ b/pythonturtle/application.py
@@ -16,8 +16,8 @@ except ModuleNotFoundError:
           "the appropriate prerequisites for your operating system.")
     print("Please consult the installation instructions in the README at "
           "https://github.com/cool-RR/PythonTurtle#installation")
-    from sys import exit
-    exit(255)
+    import sys
+    sys.exit(255)
 
 import pythonturtle
 

--- a/pythonturtle/application.py
+++ b/pythonturtle/application.py
@@ -5,11 +5,19 @@ the main window of PythonTurtle.
 import multiprocessing
 import os
 
-import wx
-import wx.adv
-import wx.aui
-import wx.lib.buttons
-import wx.lib.scrolledpanel
+try:
+    import wx
+    import wx.adv
+    import wx.aui
+    import wx.lib.buttons
+    import wx.lib.scrolledpanel
+except ModuleNotFoundError:
+    print("wxPython doesn't seem to be installed. You need to install "
+          "the appropriate prerequisites for your operating system.")
+    print("Please consult the installation instructions in the README at "
+          "https://github.com/cool-RR/PythonTurtle#installation")
+    from sys import exit
+    exit(255)
 
 import pythonturtle
 

--- a/pythonturtle/application.py
+++ b/pythonturtle/application.py
@@ -190,18 +190,18 @@ class ApplicationWindow(wx.Frame):
         return self.Close()
 
     def init_about_dialog_info(self):
-        info = self.about_dialog_info = \
-            wx.adv.AboutDialogInfo()
+        info = self.about_dialog_info = wx.adv.AboutDialogInfo()
 
         description = open(from_resource_folder('about.txt')).read()
         license_terms = open(from_resource_folder('license.txt')).read()
+        license_copyright = license_terms.split(os.linesep)[0]
         developer_list = open(from_resource_folder('developers.txt')
                               ).read().split(os.linesep)
 
         info.SetDescription(description)
         info.SetLicence(license_terms)
-        info.SetCopyright(license_terms.split(os.linesep)[0])
-        info.SetName("PythonTurtle")
+        info.SetCopyright(license_copyright)
+        info.SetName(pythonturtle.__product_name__)
         info.SetVersion(pythonturtle.__version__)
         info.SetWebSite(pythonturtle.__url__)
         info.SetDevelopers(developer_list)

--- a/pythonturtle/application.py
+++ b/pythonturtle/application.py
@@ -25,7 +25,7 @@ from . import helppages
 from . import shelltoprocess
 from . import turtleprocess
 from . import turtlewidget
-from .misc.helpers import from_resource_folder
+from .misc.helpers import resource_filename, resource_string
 
 
 class ApplicationWindow(wx.Frame):
@@ -36,7 +36,7 @@ class ApplicationWindow(wx.Frame):
     def __init__(self, *args, **keywords):
         wx.Frame.__init__(self, *args, **keywords)
         self.SetDoubleBuffered(True)
-        self.SetIcon(wx.Icon(from_resource_folder("icon.ico"),
+        self.SetIcon(wx.Icon(resource_filename("icon.ico"),
                              wx.BITMAP_TYPE_ICO))
 
         self.init_help_screen()
@@ -62,8 +62,7 @@ class ApplicationWindow(wx.Frame):
         self.help_open_button_panel = \
             wx.Panel(parent=self.bottom_sizer_panel)
 
-        help_open_button_bitmap = wx.Bitmap(
-            from_resource_folder("teach_me.png"))
+        help_open_button_bitmap = wx.Bitmap(resource_filename("teach_me.png"))
         self.help_open_button = wx.lib.buttons.GenBitmapButton(
             self.help_open_button_panel, -1, help_open_button_bitmap)
         self.help_open_button_sizer = wx.BoxSizer(wx.VERTICAL)
@@ -162,7 +161,7 @@ class ApplicationWindow(wx.Frame):
         self.help_screen.SetSizer(self.help_screen_sizer)
 
         help_close_button_bitmap = wx.Bitmap(
-            from_resource_folder("lets_code.png"))
+            resource_filename("lets_code.png"))
         self.help_close_button = wx.lib.buttons.GenBitmapButton(
             self.help_close_button_panel, -1, help_close_button_bitmap)
         self.help_close_button_sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -200,11 +199,10 @@ class ApplicationWindow(wx.Frame):
     def init_about_dialog_info(self):
         info = self.about_dialog_info = wx.adv.AboutDialogInfo()
 
-        description = open(from_resource_folder('about.txt')).read()
-        license_terms = open(from_resource_folder('license.txt')).read()
+        description = resource_string('about.txt')
+        license_terms = resource_string('license.txt')
         license_copyright = license_terms.split(os.linesep)[0]
-        developer_list = open(from_resource_folder('developers.txt')
-                              ).read().split(os.linesep)
+        developer_list = resource_string('developers.txt').split(os.linesep)
 
         info.SetDescription(description)
         info.SetLicence(license_terms)
@@ -213,7 +211,7 @@ class ApplicationWindow(wx.Frame):
         info.SetVersion(pythonturtle.__version__)
         info.SetWebSite(pythonturtle.__url__)
         info.SetDevelopers(developer_list)
-        info.SetIcon(wx.Icon(from_resource_folder("turtle.png")))
+        info.SetIcon(wx.Icon(resource_filename("turtle.png")))
 
     def on_about(self, event=None):
         wx.adv.AboutBox(self.about_dialog_info, self)

--- a/pythonturtle/helppages.py
+++ b/pythonturtle/helppages.py
@@ -5,7 +5,7 @@ import wx
 
 from wx.lib.scrolledpanel import ScrolledPanel
 
-from .misc.helpers import from_resource_folder
+from .misc.helpers import resource_filename
 
 
 class CustomScrolledPanel(ScrolledPanel):
@@ -66,10 +66,10 @@ def page_list(parent=None):
     Generate and return list of help pages for being displayed.
     """
     help_images_list = [
-        ["Level 1", from_resource_folder("help1.png")],
-        ["Level 2", from_resource_folder("help2.png")],
-        ["Level 3", from_resource_folder("help3.png")],
-        ["Level 4", from_resource_folder("help4.png")],
+        ["Level 1", resource_filename("help1.png")],
+        ["Level 2", resource_filename("help2.png")],
+        ["Level 3", resource_filename("help3.png")],
+        ["Level 4", resource_filename("help4.png")],
     ]
 
     pages = [

--- a/pythonturtle/helppages.py
+++ b/pythonturtle/helppages.py
@@ -26,11 +26,10 @@ class CustomScrolledPanel(ScrolledPanel):
         if key in (wx.WXK_HOME, wx.WXK_NUMPAD_HOME):
             self.scroll_home()
             return
-        elif key in (wx.WXK_END, wx.WXK_NUMPAD_END):
+        if key in (wx.WXK_END, wx.WXK_NUMPAD_END):
             self.scroll_end()
             return
-        else:
-            event.Skip()
+        event.Skip()
 
     def scroll_home(self):
         """

--- a/pythonturtle/misc/helpers.py
+++ b/pythonturtle/misc/helpers.py
@@ -2,9 +2,11 @@
 Various helper functions used by PythonTurtle.
 """
 import math
-import os
+import pkg_resources
 import queue
 import sys
+
+import pythonturtle
 
 
 def deg_to_rad(deg):
@@ -31,13 +33,23 @@ def dump_queue(my_queue):
             return result
 
 
-def from_resource_folder(filename):
+def resource_filename(filename):
     """
     Absolute path for a file assumed to be in resources folder.
+
+    Should be avoided for performance reasons as of
+    https://setuptools.readthedocs.io/en/latest/setuptools.html
+    #accessing-data-files-at-runtime
     """
-    my_location = os.path.dirname(__file__)
-    package_location = os.path.dirname(my_location)
-    return os.path.join(package_location, 'resources', filename)
+    return pkg_resources.resource_filename(pythonturtle.__name__,
+                                           '/'.join(['resources', filename]))
+
+
+def resource_string(filename):
+    """Text from a resource file."""
+    text = pkg_resources.resource_string(pythonturtle.__name__,
+                                         '/'.join(['resources', filename]))
+    return text.decode()
 
 
 def log(x):

--- a/pythonturtle/misc/helpers.py
+++ b/pythonturtle/misc/helpers.py
@@ -2,9 +2,9 @@
 Various helper functions used by PythonTurtle.
 """
 import math
-import pkg_resources
 import queue
 import sys
+import pkg_resources
 
 import pythonturtle
 

--- a/pythonturtle/misc/smartsleep.py
+++ b/pythonturtle/misc/smartsleep.py
@@ -6,7 +6,7 @@ import time
 # from .helpers import log
 
 
-class Sleeper(object):
+class Sleeper:
     """
     A smarter way to use `time.sleep()`, implemented as a context manager.
     Use it like this:
@@ -31,6 +31,5 @@ class Sleeper(object):
         if interval_gone >= self.interval:
             # log("didn't sleep")
             return
-        else:
-            # log("slept")
-            time.sleep(self.interval - interval_gone)
+        # log("slept")
+        time.sleep(self.interval - interval_gone)

--- a/pythonturtle/misc/vector.py
+++ b/pythonturtle/misc/vector.py
@@ -9,6 +9,7 @@ class VectorError(Exception):
     """
 
     def __init__(self, msg):
+        super().__init__()
         self.msg = msg
 
     def __str__(self):
@@ -38,7 +39,7 @@ class Vector(tuple):
         return Vector(map(lambda x, y: x - y, self, other))
 
     def __mul__(self, other):
-        if not (isinstance(other, int) or isinstance(other, float)):
+        if not isinstance(other, (int, float)):
             raise VectorError("right hand side is illegal")
         return Vector(map(lambda x: x * other, self))
 
@@ -46,7 +47,7 @@ class Vector(tuple):
         return self * other
 
     def __truediv__(self, other):
-        if not (isinstance(other, int) or isinstance(other, float)):
+        if not isinstance(other, (int, float)):
             raise VectorError("right hand side is illegal")
         return Vector(map(lambda x: x / other, self))
 

--- a/pythonturtle/my_turtle.py
+++ b/pythonturtle/my_turtle.py
@@ -43,7 +43,7 @@ def to_my_pos(pos):
     return -pos + origin
 
 
-class Turtle(object):
+class Turtle:
     """
     A Turtle object defines a turtle by its attributes, such as
     position, orientation, color, etc. See source of __init__ for

--- a/pythonturtle/shelltoprocess/console.py
+++ b/pythonturtle/shelltoprocess/console.py
@@ -1,14 +1,14 @@
 """
 See documentation for the class Console defined here.
 """
-import code
+from code import InteractiveConsole
 import sys
 import traceback
 
 from wx.py.pseudo import PseudoFileIn, PseudoFileOut, PseudoFileErr
 
 
-class Console(code.InteractiveConsole):
+class Console(InteractiveConsole):
     """
     Console based on code.InteractiveConsole. You are supposed to run this
     console in a process you create with the `multiprocessing` package.
@@ -19,7 +19,7 @@ class Console(code.InteractiveConsole):
     """
 
     def __init__(self, queue_pack, *args, **kwargs):
-        code.InteractiveConsole.__init__(self, *args, **kwargs)
+        super().__init__(self, *args, **kwargs)
 
         (self.input_queue,
          self.output_queue,

--- a/pythonturtle/shelltoprocess/console.py
+++ b/pythonturtle/shelltoprocess/console.py
@@ -19,7 +19,7 @@ class Console(InteractiveConsole):
     """
 
     def __init__(self, queue_pack, *args, **kwargs):
-        super().__init__(self, *args, **kwargs)
+        InteractiveConsole.__init__(self, *args, **kwargs)
 
         (self.input_queue,
          self.output_queue,

--- a/pythonturtle/shelltoprocess/forkedpyshell.py
+++ b/pythonturtle/shelltoprocess/forkedpyshell.py
@@ -784,11 +784,11 @@ Platform: %s""" % (
 
         # unique (no duplicate words
         # oneliner from german python forum => unique list
-        unlist = [thlist[i] for i in xrange(len(thlist))
+        unlist = [thlist[i] for i in range(len(thlist))
                   if thlist[i] not in thlist[:i]]
 
         # sort lowercase
-        unlist.sort(lambda a, b: cmp(a.lower(), b.lower()))
+        unlist.sort(lambda a, b: a.lower() == b.lower())
 
         # this is more convenient, isn't it?
         self.AutoCompSetIgnoreCase(True)

--- a/pythonturtle/turtleprocess.py
+++ b/pythonturtle/turtleprocess.py
@@ -67,7 +67,7 @@ class TurtleProcess(multiprocessing.Process):
             angle = from_my_angle(self.turtle.orientation)
             unit_vector = Vector((math.sin(angle), math.cos(angle))) * sign
             step = distance_per_frame * unit_vector
-            for i in range(steps - 1):
+            for _ in range(steps - 1):
                 with smartsleep.Sleeper(self.FRAME_TIME):
                     self.turtle.pos += step
                     self.send_report()
@@ -93,7 +93,7 @@ class TurtleProcess(multiprocessing.Process):
             angle_per_frame = self.FRAME_TIME * self.turtle.ANGULAR_SPEED
             steps = int(math.ceil(angle / float(angle_per_frame)))
             step = angle_per_frame * sign
-            for i in range(steps - 1):
+            for _ in range(steps - 1):
                 with smartsleep.Sleeper(self.FRAME_TIME):
                     self.turtle.orientation += step
                     self.send_report()

--- a/pythonturtle/turtlewidget.py
+++ b/pythonturtle/turtlewidget.py
@@ -54,7 +54,7 @@ class TurtleWidget(wx.Panel):
 
             self.turtle = turtle_report
         del dc
-        if len(turtle_reports) > 0:
+        if turtle_reports:
             self.Refresh()
 
         dc = wx.PaintDC(self)

--- a/pythonturtle/turtlewidget.py
+++ b/pythonturtle/turtlewidget.py
@@ -3,7 +3,7 @@ A TurtleWidget display the turtle and all the drawings that it made.
 """
 import wx
 
-from .misc.helpers import dump_queue, from_resource_folder
+from .misc.helpers import dump_queue, resource_filename
 from .misc.vector import Vector
 from .my_turtle import BITMAP_SIZE, Turtle, from_my_pos, from_my_angle
 
@@ -19,7 +19,7 @@ class TurtleWidget(wx.Panel):
                           *args, **kwargs)
 
         self.BACKGROUND_COLOR = wx.Colour(212, 208, 200)
-        self.TURTLE_IMAGE = wx.Bitmap(from_resource_folder("turtle.png"))
+        self.TURTLE_IMAGE = wx.Bitmap(resource_filename("turtle.png"))
 
         self.turtle = Turtle()
         # bitmap = self.bitmap = wx.EmptyBitmapRGBA(2000, 1200,

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,9 @@ setup(
     author_email='ram@rachum.com',
     url=package.__url__,
     license=package.__license__,
-    include_package_data=True,
     packages=find_packages(exclude=['tests']),
+    include_package_data=True,
     install_requires=['wxPython'],
     tests_require=['tox'],
-    zip_safe=False,
+    zip_safe=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Packaging implementation for PythonTurtle.
+"""
+from os.path import dirname, join
+from setuptools import setup, find_packages
+
+import pythonturtle as package
+
+
+def read_file(filename):
+    """Source the contents of a file"""
+    with open(join(dirname(__file__), filename)) as file:
+        return file.read()
+
+
+setup(
+    name=package.__name__,
+    version=package.__version__,
+    description=package.__doc__,
+    long_description=read_file('README.md'),
+    long_description_content_type='text/markdown',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ],
+    keywords=['turtle', 'learning', 'children', 'beginners', 'logo '],
+    author='Ram Rachum',
+    author_email='ram@rachum.com',
+    url=package.__url__,
+    license=package.__license__,
+    include_package_data=True,
+    packages=find_packages(exclude=['tests']),
+    install_requires=['wxPython'],
+    tests_require=['tox'],
+    zip_safe=False,
+)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     license=package.__license__,
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
-    install_requires=['wxPython'],
+    # install_requires=['wxPython'],
     tests_require=['tox'],
     zip_safe=True,
 )

--- a/tests/acceptance/features/module-imports.feature
+++ b/tests/acceptance/features/module-imports.feature
@@ -1,0 +1,9 @@
+Feature: Basic verification of Python version support
+  As a PythonTurtle developer
+  I want Python to import modules successfully
+  So that I can prove that the program would start up
+
+  Scenario: Try to import major modules
+    Given PythonTurtle is installed
+    When I import major modules
+    Then the modules loaded correctly

--- a/tests/acceptance/steps/given.py
+++ b/tests/acceptance/steps/given.py
@@ -1,0 +1,12 @@
+"""
+'Given' step implementations for acceptance tests.  Powered by behave.
+"""
+from behave import given
+
+
+@given(u'PythonTurtle is installed')
+def step_impl(context):
+    """
+    Running the test with Tox this should be taken for granted
+    """
+    pass

--- a/tests/acceptance/steps/then.py
+++ b/tests/acceptance/steps/then.py
@@ -1,0 +1,20 @@
+"""
+'Then' step implementations for acceptance tests.  Powered by behave.
+"""
+from behave import then
+
+
+@then(u'the modules loaded correctly')
+def step_impl(context):
+    """
+    Do some ultra-basic verifications
+    """
+    [
+        pythonturtle,
+        pythonturtle_misc,
+        pythonturtle_shelltoprocess
+    ] = context.imported_modules
+
+    assert pythonturtle.__version__ is not None
+    assert pythonturtle_misc is not None
+    assert pythonturtle_shelltoprocess is not None

--- a/tests/acceptance/steps/when.py
+++ b/tests/acceptance/steps/when.py
@@ -1,0 +1,20 @@
+"""
+'When' step implementations for acceptance tests.  Powered by behave.
+"""
+from behave import when
+
+
+@when(u'I import major modules')
+def step_impl(context):
+    """
+    Try to import PythonTurtle module
+    """
+    import pythonturtle
+    import pythonturtle.misc
+    import pythonturtle.shelltoprocess
+
+    context.imported_modules = [
+        pythonturtle,
+        pythonturtle.misc,
+        pythonturtle.shelltoprocess,
+    ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,36 +1,53 @@
+# Tox configuration for linting and tests.
+#
+# IMPORTANT NOTE:
+# - Installing wxPython is non-trivial on GNU/Linux. We need to install wheels from a dedicated repository,
+#   located at https://extras.wxpython.org/wxPython4/extras/linux/. For beackground reading see
+#   https://wiki.wxpython.org/How%20to%20install%20wxPython#Installing_wxPython-Phoenix_using_pip
+# - The wheel repository specified via --find-links below matches the build environment on Travis CI.
+# - For local Tox runs adapt the wheel repository URLs to match your local environment.
+
 [tox]
 envlist =
     flake8
     pylint
-    py26
-    py27
-    py35
+    pypy3
     py36
     py37
-    pypy
-    pypy3
-skipsdist = true
+
+[testenv]
+deps = behave
+commands =
+    pip install --find-links https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-14.04 wxPython
+    behave
 
 [testenv:flake8]
+basepython = python3.6
 deps = flake8
 commands = flake8 {posargs}
 
 [testenv:pylint]
+basepython = python3.6
 deps = pylint
-whitelist_externals = find
 commands =
-    find packaging_scripts/ -name *.py -exec pylint --rcfile tox.ini \{\} ;
-    find src/almostimportstdlib/ -name *.py -exec pylint --rcfile tox.ini \{\} ;
-    find src/misc/ -name *.py -exec pylint --rcfile tox.ini \{\} ;
-    find src/shelltoprocess/ -name *.py -exec pylint --rcfile tox.ini \{\} ;
-    pylint --rcfile tox.ini {posargs:src}
+    pip install --find-links https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-14.04 wxPython
+    pylint --rcfile tox.ini {posargs:pythonturtle}
+
+[behave]
+# default_format = progress
+junit = yes
+junit_directory = tests/reports
+paths = tests/acceptance
+show_skipped = no
+summary = no
 
 [flake8]
 exclude =
     .cache
     .git
     .tox
-    osx_dist
+    build
+    dist
 
 [pylint]
 reports = no

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@
 envlist =
     flake8
     pylint
-    pypy3
     py36
     py37
 

--- a/tox.ini
+++ b/tox.ini
@@ -49,4 +49,5 @@ exclude =
     dist
 
 [pylint]
+disable = attribute-defined-outside-init,invalid-name,missing-docstring,no-member,self-cls-assignment,too-few-public-methods,too-many-instance-attributes,too-many-locals,too-many-statements,unused-argument
 reports = no

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ envlist =
 [testenv]
 deps = behave
 commands =
-    pip install --find-links https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-14.04 wxPython
+    pip install --find-links https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04 wxPython
     behave
 
 [testenv:flake8]
@@ -30,7 +30,7 @@ commands = flake8 {posargs}
 basepython = python3.6
 deps = pylint
 commands =
-    pip install --find-links https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-14.04 wxPython
+    pip install --find-links https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04 wxPython
     pylint --rcfile tox.ini {posargs:pythonturtle}
 
 [behave]


### PR DESCRIPTION
This PR introduces a number of additions and changes that make building and deploying a Python package easier and cleaner:

- Load resources using [pkg_resources](https://setuptools.readthedocs.io/en/latest/pkg_resources.html) (from `setuptools`) instead of directly from file system
- Handle missing dependencies at runtime (print error message explaining what to do)
- Add a test suite configuration and first tests (BDD)
- Drop Python 2 for linting, tests and builds
