### PR TITLE
Refactor Travis configuration (avoid install in publish stage)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ python:
 - 3.6
 - 3.7
 
-script:
+install:
 - pip install tox-travis
+script:
 - tox
 
 stages:
@@ -31,6 +32,7 @@ jobs:
       user: coolRR
       password:
         secure: fdbhH+rsqfG9WfILlBZXlNNSXZVHrfBH9zWa7kKiUY55GMYKli+u/MzG1i6Ezn53Vg1wL1NTQMm5rFbbUfBE2l5/+S191saBZGApEhQZhulSkG702FCbpuGs1a26Zm+dhjyiRvuNdnPB8BA61uHSpWFzDgpLurGsZB0TyB2hZqv7LFL1eG56mKh70LTIDO5XmDh5/yDEXfc23M2nS7Zwx2xJEM047Fay/yeZSjo+LEYgCoTM/z9TftyxkyuLOGsiRoBMwL7eb7wKJzk79vSAvgZP/fSuAqc8ut1lrk1S9OIO4I9s7Zpi1QneJSGDJu4IHfV3nlge/+tlN8aeLA6GsSy/RrrzueBdtYTpbt34vO5rVfhJwjHIKTQa4GUF0R6gCiQ0JjJiXLC+UAbePZxzAKQWaxJWWpqq8L9e+LlHWpEtuB4jEqncFs6FeTT7mTWz2HMTQvvIVAsI2xFkItY4yCpE3P5+5f6UgqwqFpuKCXWF6ohQ090wTlNxN5cikNSYdPPQj7hypKzWrYcH5z4Z4pU63mnO2fZgTEZomvYKXa9mcdtZcCBhPNJW9WTgxqKSouPcjYc4me9wk4wv4ncJaCPLlxbuW7T/Nv+Xy/HYn7eljRapnu7/XcVQgB6gG4vxbRkkLkr1Ybj0xcR2neAQcxhBBqzfCyQezh210dPGqF8=
+    install: skip
     script: skip
     on:
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,36 @@
 ---
 dist: xenial
 sudo: true
-
 language: python
+
 python:
-  - 3.6
-  - 3.7
+- 3.6
+- 3.7
+
+script:
+- pip install tox-travis
+- tox
 
 stages:
-  - lint
-  - test
-  - publish
-
-env:  # enable allow_failures
-matrix:
-  allow_failures:
-    - env: TOXENV=pylint
-    - python: 3.7
+- lint
+- test
+- publish
 
 jobs:
+  allow_failures:
+  - env: TOXENV=pylint
+  - python: 3.7
+
   include:
-    - { stage: lint, python: 3.6, env: TOXENV=flake8 }
-    - { stage: lint, python: 3.6, env: TOXENV=pylint }
+  - { stage: lint, python: 3.6, env: TOXENV=flake8 }
+  - { stage: lint, python: 3.6, env: TOXENV=pylint }
 
-    - stage: publish
-      script: skip
-      deploy:
-        provider: pypi
-        user: coolRR
-        password:
-          secure: fdbhH+rsqfG9WfILlBZXlNNSXZVHrfBH9zWa7kKiUY55GMYKli+u/MzG1i6Ezn53Vg1wL1NTQMm5rFbbUfBE2l5/+S191saBZGApEhQZhulSkG702FCbpuGs1a26Zm+dhjyiRvuNdnPB8BA61uHSpWFzDgpLurGsZB0TyB2hZqv7LFL1eG56mKh70LTIDO5XmDh5/yDEXfc23M2nS7Zwx2xJEM047Fay/yeZSjo+LEYgCoTM/z9TftyxkyuLOGsiRoBMwL7eb7wKJzk79vSAvgZP/fSuAqc8ut1lrk1S9OIO4I9s7Zpi1QneJSGDJu4IHfV3nlge/+tlN8aeLA6GsSy/RrrzueBdtYTpbt34vO5rVfhJwjHIKTQa4GUF0R6gCiQ0JjJiXLC+UAbePZxzAKQWaxJWWpqq8L9e+LlHWpEtuB4jEqncFs6FeTT7mTWz2HMTQvvIVAsI2xFkItY4yCpE3P5+5f6UgqwqFpuKCXWF6ohQ090wTlNxN5cikNSYdPPQj7hypKzWrYcH5z4Z4pU63mnO2fZgTEZomvYKXa9mcdtZcCBhPNJW9WTgxqKSouPcjYc4me9wk4wv4ncJaCPLlxbuW7T/Nv+Xy/HYn7eljRapnu7/XcVQgB6gG4vxbRkkLkr1Ybj0xcR2neAQcxhBBqzfCyQezh210dPGqF8=
-      on:
-        tags: true
-
-before_install:
-  - sudo apt-get update
-  - PYTHON_MAJOR=$(python -c 'import sys; print(sys.version[0])')
-  # - if [ $PYTHON_MAJOR = '3' ]; then sudo apt-get install -y python3-wxgtk4.0; fi
-  - dpkg -l *wxgtk*
-
-install: pip install tox-travis
-script: tox
+  - stage: publish
+    deploy:
+      provider: pypi
+      user: coolRR
+      password:
+        secure: fdbhH+rsqfG9WfILlBZXlNNSXZVHrfBH9zWa7kKiUY55GMYKli+u/MzG1i6Ezn53Vg1wL1NTQMm5rFbbUfBE2l5/+S191saBZGApEhQZhulSkG702FCbpuGs1a26Zm+dhjyiRvuNdnPB8BA61uHSpWFzDgpLurGsZB0TyB2hZqv7LFL1eG56mKh70LTIDO5XmDh5/yDEXfc23M2nS7Zwx2xJEM047Fay/yeZSjo+LEYgCoTM/z9TftyxkyuLOGsiRoBMwL7eb7wKJzk79vSAvgZP/fSuAqc8ut1lrk1S9OIO4I9s7Zpi1QneJSGDJu4IHfV3nlge/+tlN8aeLA6GsSy/RrrzueBdtYTpbt34vO5rVfhJwjHIKTQa4GUF0R6gCiQ0JjJiXLC+UAbePZxzAKQWaxJWWpqq8L9e+LlHWpEtuB4jEqncFs6FeTT7mTWz2HMTQvvIVAsI2xFkItY4yCpE3P5+5f6UgqwqFpuKCXWF6ohQ090wTlNxN5cikNSYdPPQj7hypKzWrYcH5z4Z4pU63mnO2fZgTEZomvYKXa9mcdtZcCBhPNJW9WTgxqKSouPcjYc4me9wk4wv4ncJaCPLlxbuW7T/Nv+Xy/HYn7eljRapnu7/XcVQgB6gG4vxbRkkLkr1Ybj0xcR2neAQcxhBBqzfCyQezh210dPGqF8=
+    script: skip
+    on:
+      tags: true

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     project_urls={
         'Source': 'https://github.com/cool-RR/PythonTurtle',
     },
-    keywords=['turtle', 'learning', 'children', 'beginners', 'logo '],
+    keywords=['turtle', 'learning', 'children', 'beginners', 'logo'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: MacOS X',


### PR DESCRIPTION
Travis CI is disturbing for a number of reasons:

1. The `install` section is run even in the `publish` stage (where this is not needed).
1. When the deployment is skipped (e.g. tag not on `master` branch) the build passes successfully. (WTF!)

This PR tries to address the former problem.