### PR TITLE
Use GITHUB_TOKEN for automatic deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
     - bash -c "mv -v out/Python*AppImage PythonTurtle.AppImage"
     deploy:
       provider: releases
-      api_key: "GITHUB OAUTH TOKEN"
+      api_key: $GITHUB_TOKEN
       file: PythonTurtle.AppImage
       skip_cleanup: true
       on:
@@ -73,7 +73,7 @@ jobs:
     - ./setup.py clean bundle
     deploy:
       provider: releases
-      api_key: "GITHUB OAUTH TOKEN"
+      api_key: $GITHUB_TOKEN
       file: dist/PythonTurtle
       skip_cleanup: true
       on:
@@ -91,7 +91,7 @@ jobs:
     - ./setup.py clean bundle
     deploy:
       provider: releases
-      api_key: "GITHUB OAUTH TOKEN"
+      api_key: $GITHUB_TOKEN
       file: dist/PythonTurtle
       skip_cleanup: true
       on:


### PR DESCRIPTION
This change will probably fix a small issue mentioned in https://github.com/cool-RR/PythonTurtle/issues/107#issuecomment-482775421.

@cool-RR, after merging this PR can you add a Git tag to `master` and push it to see the pipeline in action? e.g.

```console
git checkout master
git tag 0.2.0
git push --tags
```