### PR TITLE
feat: add single-letter shortcuts + internationalization

### DIFF
--- a/pythonturtle/application.py
+++ b/pythonturtle/application.py
@@ -33,8 +33,37 @@ class ApplicationWindow(wx.Frame):
     The main window of PythonTurtle.
     """
 
+    def init_locale(self):
+
+        self.languages = {
+            "System default" : wx.LANGUAGE_DEFAULT,
+            "English"        : wx.LANGUAGE_ENGLISH,
+            "French"         : wx.LANGUAGE_FRENCH,
+        }
+        self.locale = wx.Locale()
+        self.locale.AddCatalogLookupPathPrefix("./pythonturtle/locale")
+
+        #asked_lang = "French" # TODO implement config file + settings
+        #lang = self.languages[asked_lang]
+        lang = self.languages["System default"]
+
+        if lang == wx.LANGUAGE_ENGLISH:
+            return
+            
+        if not self.locale.Init(lang):
+            wx.LogWarning("This language is not supported by the system, falls back to English.")
+            return
+            
+        if not self.locale.AddCatalog("turtle"):
+            wx.LogError("Couldn't find the catalog for locale '" + self.locale.GetCanonicalName() + "', falls back to English.")
+            return
+
+
     def __init__(self, *args, **keywords):
         wx.Frame.__init__(self, *args, **keywords)
+
+        self.init_locale()
+
         self.SetDoubleBuffered(True)
         self.SetIcon(wx.Icon(resource_filename("icon.ico"),
                              wx.BITMAP_TYPE_ICO))
@@ -105,28 +134,30 @@ class ApplicationWindow(wx.Frame):
         """
         Initialize the menu bar.
         """
+        _ = wx.GetTranslation
+
         self.menu_bar = wx.MenuBar()
 
         self.file_menu = wx.Menu()
-        self.exit_menu_item = wx.MenuItem(self.file_menu, -1, 'E&xit')
+        self.exit_menu_item = wx.MenuItem(self.file_menu, -1, _('E&xit'))
         self.file_menu.Append(self.exit_menu_item)
         self.Bind(wx.EVT_MENU, self.on_exit, source=self.exit_menu_item)
 
         self.help_menu = wx.Menu()
 
         self.help_menu_item = \
-            wx.MenuItem(self.help_menu, -1, '&Help\tF1', kind=wx.ITEM_CHECK)
+            wx.MenuItem(self.help_menu, -1, _('&Help\tF1'), kind=wx.ITEM_CHECK)
         self.help_menu.Append(self.help_menu_item)
         self.Bind(wx.EVT_MENU, self.toggle_help, source=self.help_menu_item)
 
         self.help_menu.AppendSeparator()
 
-        self.about_menu_item = wx.MenuItem(self.help_menu, -1, "&About...")
+        self.about_menu_item = wx.MenuItem(self.help_menu, -1, _("&About..."))
         self.help_menu.Append(self.about_menu_item)
         self.Bind(wx.EVT_MENU, self.on_about, source=self.about_menu_item)
 
-        self.menu_bar.Append(self.file_menu, '&File')
-        self.menu_bar.Append(self.help_menu, '&Help')
+        self.menu_bar.Append(self.file_menu, _('&Turtle'))
+        self.menu_bar.Append(self.help_menu, _('&Help'))
 
         self.SetMenuBar(self.menu_bar)
 

--- a/pythonturtle/locale/fr_FR/LC_MESSAGES/turtle.po
+++ b/pythonturtle/locale/fr_FR/LC_MESSAGES/turtle.po
@@ -1,0 +1,136 @@
+# PythonTurtle internationalization
+# Copyright (C) 2022 nojhan
+# nojhan <nojhan@nojhan.net> 2022
+msgid ""
+msgstr ""
+"Project-Id-Version: PythonTurtle\n"
+"POT-Creation-Date: 2022-01-09 17:20+0100\n"
+"PO-Revision-Date: 2022-01-09 17:20+0100\n"
+"Last-Translator: nojhan <nojhan@nojhan.net>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: pygettext.py 1.5\n"
+"Language-Team: French\n"
+"Language: fr\n"
+
+msgid "E&xit"
+msgstr "&Quitter"
+
+msgid "&Help\tF1"
+msgstr "&Aide\tF1"
+
+msgid "&Help"
+msgstr "&Aide"
+
+msgid "&About..."
+msgstr "À &Propos..."
+
+msgid "&Turtle"
+msgstr "&Tortue"
+
+msgid "go"
+msgstr "avance"
+
+msgid "turn"
+msgstr "tourne"
+
+msgid "color"
+msgstr "couleur"
+
+msgid "width"
+msgstr "largeur"
+
+msgid "visible"
+msgstr "visible"
+
+msgid "invisible"
+msgstr "invisible"
+
+msgid "pen_down"
+msgstr "stylo_bas"
+
+msgid "pen_up"
+msgstr "stylo_haut"
+
+msgid "is_visible"
+msgstr "est_visible"
+
+msgid "is_pen_down"
+msgstr "stylo_est_bas"
+
+msgid "sin"
+msgstr "sin"
+
+msgid "cos"
+msgstr "cos"
+
+msgid "turtle"
+msgstr "tortue"
+
+msgid "clear"
+msgstr "efface"
+
+msgid "reset"
+msgstr "reset"
+
+msgid "do"
+msgstr "fait"
+
+msgid "repeat"
+msgstr "répéte"
+
+# go(40)
+msgid "G"  
+msgstr "A" 
+# Avance
+
+# go(20)
+msgid "g"  
+msgstr "a" 
+# avance
+
+# turn(-90)
+msgid "L"  
+msgstr "G" 
+# Gauche
+
+# turn(-45)
+msgid "l"  
+msgstr "g" 
+# gauche
+
+# turn(90)
+msgid "R"  
+msgstr "D" 
+# Droite
+
+# turn(45)
+msgid "r"  
+msgstr "d" 
+# droite
+
+# pen_up()
+msgid "U"  
+msgstr "L" 
+# lever
+
+# pen_down()
+msgid "D"  
+msgstr "B" 
+# baisser
+
+# reset() (clear)
+msgid "C"  
+msgstr "E" 
+# efface
+
+# repeat
+msgid "P"  
+msgstr "R" 
+# Répète
+
+# do
+msgid "O"
+msgstr "F"
+# fait

--- a/pythonturtle/turtleprocess.py
+++ b/pythonturtle/turtleprocess.py
@@ -8,6 +8,7 @@ import multiprocessing
 import sys
 import time
 import builtins
+import wx
 
 from . import shelltoprocess
 from .misc import smartsleep
@@ -84,6 +85,14 @@ class TurtleProcess(multiprocessing.Process):
                 self.turtle.pos += last_step
                 self.send_report()
 
+        def g():
+            """Walk of a reasonable distance."""
+            go(20)
+
+        def G():
+            """Walk of a diagonal's distance."""
+            go(20*math.sqrt(2))
+
         def turn(angle):
             """
             Makes the turtle turn. Specify angle in degrees. A positive
@@ -109,6 +118,21 @@ class TurtleProcess(multiprocessing.Process):
                 last_step = last_angle * sign
                 self.turtle.orientation += last_step
                 self.send_report()
+
+        def t(a):
+            turn(a)
+
+        def R():
+            t(90)
+
+        def r():
+            t(45)
+
+        def L():
+            t(-90)
+
+        def l():
+            t(-45)
 
         def color(color):
             """
@@ -156,6 +180,9 @@ class TurtleProcess(multiprocessing.Process):
             self.turtle.pen_down = down
             self.send_report()
 
+        def D():
+            pen_down()
+
         def pen_up():
             """
             Puts the pen in the "up" position, making the turtle not leave a
@@ -163,6 +190,9 @@ class TurtleProcess(multiprocessing.Process):
             """
             self.turtle.pen_down = False
             self.send_report()
+
+        def U():
+            pen_up()
 
         def is_visible():
             """
@@ -221,26 +251,57 @@ class TurtleProcess(multiprocessing.Process):
             self.turtle = Turtle()
             clear()
 
+        def C():
+            reset()
+
+        def do(cmd):
+            for c in cmd:
+                locals_for_console[c]()
+
+        def repeat(cmd,times=2):
+            for i in range(times):
+                do(cmd)
+
+        def P(cmd,times=2):
+            repeat(cmd,times)
+
+        _ = wx.GetTranslation
+
         locals_for_console = {
-            "go": go,
-            "turn": turn,
-            "color": color,
-            "width": width,
-            "visible": visible,
-            "invisible": invisible,
-            "pen_down": pen_down,
-            "pen_up": pen_up,
-            "is_visible": is_visible,
-            "is_pen_down": is_pen_down,
-            "sin": sin,
-            "cos": cos,
-            "turtle": self.turtle,
-            "clear": clear,
-            "reset": reset,
+            _("go"): go,
+            _("turn"): turn,
+            _("color"): color,
+            _("width"): width,
+            _("visible"): visible,
+            _("invisible"): invisible,
+            _("pen_down"): pen_down,
+            _("pen_up"): pen_up,
+            _("is_visible"): is_visible,
+            _("is_pen_down"): is_pen_down,
+            _("sin"): sin,
+            _("cos"): cos,
+            _("turtle"): self.turtle,
+            _("clear"): clear,
+            _("reset"): reset,
+            _("do") : do,
+            _("repeat"): repeat,
+            _("do") : do,
+            _("O") : do,
+            _("g") : g, # go(20)
+            _("G") : G, # go(20√2) [for diagonals]
+            _("L") : L, # turn(-90)
+            _("l") : l, # turn(-45)
+            _("R") : R, # turn(90)
+            _("r") : r, # turn(45)
+            _("U") : U, # pen_up
+            _("D") : D, # pen_down
+            _("C") : C, # reset (clear)
+            _("P") : P, # repeat(cmd,times=2)
+
         }
 
         # A little thing I tried doing for checking if a color is
-        # valid before setting it to the turtle. Didn't work.
+        # valid before setting itPto the turtle. Didn't work.
         # import wx; app=wx.App();
         # def valid_color(color):
         #     return not wx.Pen(color).GetColour() == \


### PR DESCRIPTION
1) Adds single-letter shortcuts to the main commands.
This is useful for people having difficulties typing, e.g. people with disabilities.
This also allows for compact "functions", using the `do` and `repeat` commands with a string of letters
(e.g. `repeat("GLglGRgr",3)`.
Those also serve as an introduction to loops and can be localized.

The letters command are designed to allow for grid drawing, both on straight and diagonal segments, for example:
- a = small (straight) go, A = large (diagonal) go,
- r/l = small (diagonal) turn, R/L = large (straight) turn.

2) Localize every menus and command.
Currently with a french translation, but uses gettext (the standard tool for internationalization),
so can be easily ported to other languages.